### PR TITLE
Manually decode form parameters

### DIFF
--- a/GenotypeAssays/src/org/labkey/genotypeassays/GenotypeAssaysController.java
+++ b/GenotypeAssays/src/org/labkey/genotypeassays/GenotypeAssaysController.java
@@ -16,6 +16,7 @@
 
 package org.labkey.genotypeassays;
 
+import org.apache.commons.text.StringEscapeUtils;
 import org.json.JSONArray;
 import org.labkey.api.action.ApiResponse;
 import org.labkey.api.action.ApiSimpleResponse;
@@ -30,7 +31,6 @@ import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.security.RequiresPermission;
 import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.security.permissions.UpdatePermission;
-import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Pair;
 import org.labkey.api.util.URLHelper;
 import org.labkey.api.view.HtmlView;
@@ -132,7 +132,7 @@ public class GenotypeAssaysController extends SpringActionController
                         return null;
                     }
 
-                    String[] alleleNames = Arrays.stream(form.getAlleleNames()).map(PageFlowUtil::decode).toArray(String[]::new);
+                    String[] alleleNames = Arrays.stream(form.getAlleleNames()).map(StringEscapeUtils::unescapeHtml4).toArray(String[]::new);
                     Pair<List<Integer>, List<Integer>> ret = GenotypeAssaysManager.get().cacheAnalyses(getViewContext(), protocol, alleleNames);
                     resultProperties.put("runsCreated", ret.first);
                     resultProperties.put("runsDeleted", ret.second);

--- a/GenotypeAssays/src/org/labkey/genotypeassays/GenotypeAssaysController.java
+++ b/GenotypeAssays/src/org/labkey/genotypeassays/GenotypeAssaysController.java
@@ -30,6 +30,7 @@ import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.security.RequiresPermission;
 import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.security.permissions.UpdatePermission;
+import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Pair;
 import org.labkey.api.util.URLHelper;
 import org.labkey.api.view.HtmlView;
@@ -37,6 +38,7 @@ import org.springframework.validation.BindException;
 import org.springframework.validation.Errors;
 import org.springframework.web.servlet.ModelAndView;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -130,7 +132,8 @@ public class GenotypeAssaysController extends SpringActionController
                         return null;
                     }
 
-                    Pair<List<Integer>, List<Integer>> ret = GenotypeAssaysManager.get().cacheAnalyses(getViewContext(), protocol, form.getAlleleNames());
+                    String[] alleleNames = Arrays.stream(form.getAlleleNames()).map(PageFlowUtil::decode).toArray(String[]::new);
+                    Pair<List<Integer>, List<Integer>> ret = GenotypeAssaysManager.get().cacheAnalyses(getViewContext(), protocol, alleleNames);
                     resultProperties.put("runsCreated", ret.first);
                     resultProperties.put("runsDeleted", ret.second);
                 }

--- a/GenotypeAssays/src/org/labkey/genotypeassays/GenotypeAssaysManager.java
+++ b/GenotypeAssays/src/org/labkey/genotypeassays/GenotypeAssaysManager.java
@@ -60,6 +60,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class GenotypeAssaysManager
 {
@@ -121,6 +122,7 @@ public class GenotypeAssaysManager
             final Map<Integer, List<Map<String, Object>>> rowHash = new HashMap<>();
             final Map<Integer, Set<Integer>> toDeleteByAnalysis = new HashMap<>();
 
+            AtomicInteger records = new AtomicInteger();
             TableSelector tsAlignments = new TableSelector(tableAlignments, cols.values(), new SimpleFilter(FieldKey.fromString("key"), Arrays.asList(pks), CompareType.IN), null);
             tsAlignments.forEach(new Selector.ForEachBlock<ResultSet>()
             {
@@ -128,6 +130,7 @@ public class GenotypeAssaysManager
                 public void exec(ResultSet object) throws SQLException
                 {
                     Results rs = new ResultsImpl(object, cols);
+                    records.getAndIncrement();
 
                     int analysisId = rs.getInt(FieldKey.fromString("analysis_id"));
                     String lineages = rs.getString(FieldKey.fromString("lineages"));
@@ -166,6 +169,11 @@ public class GenotypeAssaysManager
                     rowHash.put(analysisId, rows);
                 }
             });
+
+            if (records.get() != pks.length)
+            {
+                throw new IllegalStateException("The number of records found did not match the number supplied. This indicates a problem with the import.");
+            }
 
             if (!rowHash.isEmpty())
             {


### PR DESCRIPTION
Something changed between 25.3 and 25.7 related to HTML encoding of DataRegion PKs. Below is a summary:

- We have a SQL query where the PKs values contain the delimiter string '<>'. There is a client-side form associated with a DataRegion that grabs the PKs from the checked rows using LABKEY.DataRegion.getChecked(), and POSTs them to the server using a vanilla LABKEY.Ajax.request(). That code is here:

https://github.com/bimberlabinternal/BimberLabKeyModules/blob/8a4bd6cbe954dff379f2483889d8e1dccea8332e/GenotypeAssays/resources/web/genotypeassays/window/PublishResultsWindow.js#L124

- I noticed that the PKs as returned by DataRegion.getChecked() are HTML encoded. This is different from 25.3 (more below):

<img width="448" height="194" alt="image" src="https://github.com/user-attachments/assets/ad988328-5f1e-43de-b85b-dd9be76770a4" />

- The controller gets that array of PKs using basic form binding. Prior to 25.7, this never needed to do any server-side HTML decoding. The server-side code is here:  https://github.com/bimberlabinternal/BimberLabKeyModules/blob/8a4bd6cbe954dff379f2483889d8e1dccea8332e/GenotypeAssays/src/org/labkey/genotypeassays/GenotypeAssaysController.java#L133

- Those HTML-encoded PKs are passed to a TableSelector, and this fails to find the right rows, since the PKs are encoded: https://github.com/bimberlabinternal/BimberLabKeyModules/blob/8a4bd6cbe954dff379f2483889d8e1dccea8332e/GenotypeAssays/src/org/labkey/genotypeassays/GenotypeAssaysManager.java#L124

This PR fixes the problem by adding explicit HTML decoding on the server. 

To track down what's different from 25.3, I made a list on a 25.3 server where the PK is a string (https://prime.ohsu.edu/list/ONPRC/Core%20Facilities/Genetics%20Core/MHC_Typing/grid.view?listId=7). I added similar values, and we see that on 25.3 the '<>' is not encoded.

<img width="716" height="317" alt="image" src="https://github.com/user-attachments/assets/9b84a723-a1cb-4f5d-8606-da6fb30509fe" />

Is this a deliberate change in 25.7?

